### PR TITLE
Fix compilation on Ubuntu 14.04

### DIFF
--- a/core/vmmapi.c
+++ b/core/vmmapi.c
@@ -149,7 +149,12 @@ vm_open(const char *name)
 	ctx->lowmem_limit = 2 * GB;
 	ctx->name = (char *)(ctx + 1);
 	strcpy(ctx->name, name);
-	create_vm.secure_world_enabled = trusty_enabled;
+
+	/* Set trusty enable flag */
+	if (trusty_enabled)
+		create_vm.vm_flag |= SECURE_WORLD_ENABLED;
+	else
+		create_vm.vm_flag &= (~SECURE_WORLD_ENABLED);
 
 	while (retry > 0) {
 		error = ioctl(ctx->fd, IC_CREATE_VM, &create_vm);

--- a/core/vmmapi.c
+++ b/core/vmmapi.c
@@ -118,7 +118,7 @@ vm_open(const char *name)
 	int error, retry = 10;
 	uuid_t vm_uuid;
 
-	ctx = malloc(sizeof(struct vmctx) + strlen(name) + 1);
+	ctx = calloc(1, sizeof(struct vmctx) + strlen(name) + 1);
 	assert(ctx != NULL);
 	assert(devfd == -1);
 

--- a/hw/pci/ahci.c
+++ b/hw/pci/ahci.c
@@ -1478,7 +1478,7 @@ static void
 atapi_mode_sense(struct ahci_port *p, int slot, uint8_t *cfis)
 {
 	uint8_t *acmd;
-	uint32_t tfd;
+	uint32_t tfd =0;
 	uint8_t pc, code;
 	int len;
 

--- a/hw/platform/rtc.c
+++ b/hw/platform/rtc.c
@@ -1105,9 +1105,8 @@ vrtc_init(struct vmctx *ctx, int local_time)
 	time_t curtime;
 	struct inout_port rtc_addr, rtc_data;
 
-	vrtc = malloc(sizeof(struct vrtc));
+	vrtc = calloc(1, sizeof(struct vrtc));
 	assert(vrtc != NULL);
-	memset(vrtc, 0, sizeof(struct vrtc));
 	vrtc->vm = ctx;
 	ctx->vrtc = vrtc;
 

--- a/include/pci_core.h
+++ b/include/pci_core.h
@@ -270,14 +270,14 @@ static inline void
 pci_set_cfgdata16(struct pci_vdev *pi, int offset, uint16_t val)
 {
 	assert(offset <= (PCI_REGMAX - 1) && (offset & 1) == 0);
-	*(uint16_t *)(pi->cfgdata + offset) = val;
+	*(uint16_t *)((uint16_t *)pi->cfgdata + offset) = val;
 }
 
 static inline void
 pci_set_cfgdata32(struct pci_vdev *pi, int offset, uint32_t val)
 {
 	assert(offset <= (PCI_REGMAX - 3) && (offset & 3) == 0);
-	*(uint32_t *)(pi->cfgdata + offset) = val;
+	*(uint32_t *)((uint32_t *)pi->cfgdata + offset) = val;
 }
 
 static inline uint8_t
@@ -291,14 +291,14 @@ static inline uint16_t
 pci_get_cfgdata16(struct pci_vdev *pi, int offset)
 {
 	assert(offset <= (PCI_REGMAX - 1) && (offset & 1) == 0);
-	return (*(uint16_t *)(pi->cfgdata + offset));
+	return (*(uint16_t *)((uint16_t *)pi->cfgdata + offset));
 }
 
 static inline uint32_t
 pci_get_cfgdata32(struct pci_vdev *pi, int offset)
 {
 	assert(offset <= (PCI_REGMAX - 3) && (offset & 3) == 0);
-	return (*(uint32_t *)(pi->cfgdata + offset));
+	return (*(uint32_t *)((uint32_t *)pi->cfgdata + offset));
 }
 
 #endif /* _PCI_CORE_H_ */

--- a/tools/acrntrace/acrntrace.c
+++ b/tools/acrntrace/acrntrace.c
@@ -340,12 +340,11 @@ int main(int argc, char *argv[])
 
 	/* how many cpus */
 	pcpu_num = get_cpu_num();
-	reader = malloc(sizeof(reader_struct) * pcpu_num);
+	reader = calloc(1, sizeof(reader_struct) * pcpu_num);
 	if (!reader) {
 		pr_err("Failed to allocate reader memory\n");
 		exit(EXIT_FAILURE);
 	}
-	memset(reader, 0, sizeof(reader_struct) * pcpu_num);
 
 	/* create dir for trace file */
 	if (create_trace_file_dir(trace_file_dir)) {


### PR DESCRIPTION
A couple of problems appeared on Ubuntu 14.04 (gcc 4.8.4) when we
turned on additional compiler flags with commit
519c4285cf104a594776591075ee1c6ee4d61815a. This patch fixes these
problems by adhering to the strict anti-aliasing rules and also
initializing the 'tfd' variable where the compile believed it
_could_ be used uninitialized.

Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>